### PR TITLE
Add an option to prevent triggering when not scrolling

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -462,6 +462,7 @@ describe('jQuery Waypoints', function() {
 		var currentDirection;
 		
 		beforeEach(function() {
+			currentDirection = void(0);
 			$e = $('#same1').waypoint(function(event, direction) {
 				currentDirection = direction;
 			});
@@ -482,6 +483,26 @@ describe('jQuery Waypoints', function() {
 				$e.css('top', $e.offset().top + 50 + 'px');
 				$.waypoints('refresh');
 				expect(currentDirection).toEqual('up');
+			});
+		});
+		
+		it('should not trigger waypoint.reached when refresh crosses current scroll if prevented by option', function() {
+			runs(function() {
+				$se.scrollTop($e.offset().top - 1);
+				$e = $('#same1').waypoint('destroy').waypoint(function(event, direction) {
+					currentDirection = direction;
+				}, {onlyOnScroll: true});
+			});
+			
+			waits(standardWait);
+			
+			runs(function() {
+				$e.css('top', ($e.offset().top - 50) + 'px');
+				$.waypoints('refresh');
+				expect(currentDirection).toEqual(undefined);
+				$e.css('top', $e.offset().top + 50 + 'px');
+				$.waypoints('refresh');
+				expect(currentDirection).toEqual(undefined);
 			});
 		});
 		

--- a/waypoints.js
+++ b/waypoints.js
@@ -401,7 +401,7 @@ Support:
 					the event, just as if we scrolled past it unless prevented by an
 					optional flag.
 					*/
-					if (o.options.onlyOnScrollby) return;
+					if (o.options.onlyOnScroll) return;
 					
 					if (oldOffset !== null && c.oldScroll > oldOffset && c.oldScroll <= o.offset) {
 						triggerWaypoint(o, ['up']);


### PR DESCRIPTION
Use case: I don't want the waypoint handler to be executed when the element moves across the current scroll point due to reflow after additional elements have been inserted.

When registering the waypoint, the option `onlyOnScrollby` can be set to a truthy value to prevent non-scroll-induced triggering. Default behavior is unchanged.

I didn't write any specs because currently all specs are failing for me in Chrome 13.

Let me know if you are interested in this addition.
