### PR TITLE
Updated oldScroll value so that top most waypoints would be active on page load

### DIFF
--- a/waypoints.js
+++ b/waypoints.js
@@ -105,7 +105,7 @@ Support:
 	Context = function(context) {
 		$.extend(this, {
 			element: $(context),
-			oldScroll: 0,
+			oldScroll: -1,
 			
 			/*
 			List of all elements that have been registered as waypoints.


### PR DESCRIPTION
Updated oldScroll value so that top most waypoints would be active on page load.
I'm not certain if there are any risks in setting this initialization value to -1.  I will be looking at the rest of the code tomorrow so I'll keep my eye out for issues as I go.  I had been hacking around this init thing, but I decided to just fork and see what I could see.
