### PR TITLE
Fix for reverse waypoints.

### DIFF
--- a/waypoints.js
+++ b/waypoints.js
@@ -130,7 +130,8 @@ Support:
 				pointsHit = $.grep(this.waypoints, function(el, i) {
 					return isDown ?
 						(el.offset > that.oldScroll && el.offset <= newScroll) :
-						(el.offset <= that.oldScroll && el.offset > newScroll);
+						// @author dboskovic (the +1 allows the waypoint to be hit accurately on the way back up)
+						(el.offset+1 <= that.oldScroll && el.offset+1 > newScroll);
 				}),
 				len = pointsHit.length;
 				


### PR DESCRIPTION
On the return trip, waypoints are 1px off off whatever the offset originally intended. I've made a modification that allows the waypoints to be hit accurately on the way back up.
