### PR TITLE
Offset percent behaviour

### DIFF
--- a/waypoints.js
+++ b/waypoints.js
@@ -416,7 +416,7 @@ Support:
 					else if (typeof o.options.offset === "string") {
 						var amount = parseFloat(o.options.offset);
 						adjustment = o.options.offset.indexOf("%") ?
-							Math.ceil(contextHeight * (amount / 100)) : amount;
+							-Math.ceil(o.element.height() * (amount / 100)) : amount;
 					}
 
 					/* 


### PR DESCRIPTION
I may not understood this correctly, but I expect percentage offset to trigger waypoint when i scroll to, for example, 90% of element that was used as waypoint, isn't it more logical?
Sorry, if i misunderstood the concept :)
