### PR TITLE
Update shortcuts/sticky-elements/waypoints-sticky.coffee

### DIFF
--- a/shortcuts/sticky-elements/waypoints-sticky.coffee
+++ b/shortcuts/sticky-elements/waypoints-sticky.coffee
@@ -64,6 +64,6 @@ $.waypoints 'extendFn', 'sticky', (options) ->
     $sticky = $(this).children ':first'
     shouldBeStuck = direction in ['down', 'right']
     $sticky.toggleClass options.stuckClass, shouldBeStuck
-    optHandler.call(this) if optHandler?
+    optHandler.call this,direction if optHandler?
   $wrap.waypoint options
   this


### PR DESCRIPTION
According to the sticky documentation: This options object is just an extension of the regular Waypoints options object, so you can pass along any traditional options you may want.
However the handler method was overwritten with the original implementation so this goes against the documentation so I added a clause to run the inputed handler inside the new options.handler
