### PR TITLE
Update shortcuts/infinite-scroll/waypoints-infinite.js

### DIFF
--- a/shortcuts/infinite-scroll/waypoints-infinite.js
+++ b/shortcuts/infinite-scroll/waypoints-infinite.js
@@ -33,7 +33,7 @@ https://github.com/imakewebthings/jquery-waypoints/blob/master/licenses.txt
       $container = options.container === 'auto' ? this : $(options.container);
       options.handler = function(direction) {
         var $this;
-        if (direction === 'down' || direction === 'right') {
+        if ( (direction === 'down' || direction === 'right') && $(options.more).length) {
           $this = $(this);
           options.onBeforePageLoad();
           $this.waypoint('disable');


### PR DESCRIPTION
Added a check if options.more actually exists, as at the jQuery.get() defaults to location.href if url parameter is undefined. 
