### PR TITLE
Update sticky.coffee

### DIFF
--- a/test/sticky.coffee
+++ b/test/sticky.coffee
@@ -10,7 +10,7 @@ describe 'Waypoints Sticky Elements Shortcut', ->
     loadFixtures 'sticky.html'
     $sticky = $ '.sticky'
     handlerSpy = jasmine.createSpy 'on handler'
-    $return = $sticky.waypoint 'sticky'
+    $return = $sticky.waypoint 'sticky',
       handler: handlerSpy
 
   it 'returns the same jQuery object for chaining', ->


### PR DESCRIPTION
fix syntax error: missing "," between parameters
