### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "jquery-waypoints",
+  "version": "2.0.3",
+  "main": "waypoints.js",
+  "description": "A jQuery plugin that makes it easy to execute a function whenever you scroll to an element.",
+  "ignore": [
+    "**/.*",
+    "**/*.coffee",
+    "**/*.html",
+    "bower_components",
+    "examples",
+    "node_modules",
+    "Makefile",
+    "test"
+  ],
+  "dependencies": {
+    "jquery" : ">=1.8"
+  }
+}


### PR DESCRIPTION
This file allows this package to be installed using Bower. The package
has already been registered as `jquery-waypoints` in the Bower package
registry. It can now be installed by executing:

  bower install jquery-waypoints

More information on Bower can be found at:

  https://github.com/bower/bower
  http://bower.io
