### PR TITLE
Update typo in the docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,7 +465,7 @@
             </li>
           </ul>
 
-          <p>Returns a jQuery object containing the previous waypoint, as measured by the waypoints' trigger locations.</p>
+          <p>Returns a jQuery object containing the next waypoint, as measured by the waypoints' trigger locations.</p>
 
           <pre><code><span class="fn">$</span>(<span class="str">'#thing'</span>).<span class="fn">waypoint</span>(...);
 <span class="fn">$</span>(<span class="str">'#thing-farther-down'</span>).<span class="fn">waypoint</span>(...);


### PR DESCRIPTION
The description for .waypoint('next') was the same as .waypoint('prev')
