### PR TITLE
Add bind/unbindScroll() to Context

### DIFF
--- a/waypoints.js
+++ b/waypoints.js
@@ -46,28 +46,17 @@ https://github.com/imakewebthings/jquery-waypoints/blob/master/licenses.txt
         this.didResize = false;
         this.didScroll = false;
         this.id = 'context' + contextCounter++;
-        this.oldScroll = {
-          x: $element.scrollLeft(),
-          y: $element.scrollTop()
-        };
         this.waypoints = {
           horizontal: {},
           vertical: {}
         };
         this.element[contextKey] = this.id;
+	//TODO change Context accessibility
+	$element.data('wp-context', this);
         contexts[this.id] = this;
-        $element.bind(scrollEvent, function() {
-          var scrollHandler;
-
-          if (!(_this.didScroll || isTouch)) {
-            _this.didScroll = true;
-            scrollHandler = function() {
-              _this.doScroll();
-              return _this.didScroll = false;
-            };
-            return window.setTimeout(scrollHandler, $[wps].settings.scrollThrottle);
-          }
-        });
+        
+        this.bindScroll();
+        
         $element.bind(resizeEvent, function() {
           var resizeHandler;
 
@@ -82,6 +71,32 @@ https://github.com/imakewebthings/jquery-waypoints/blob/master/licenses.txt
         });
       }
 
+      Context.prototype.bindScroll = function(){
+	//reset 
+	this.oldScroll = {
+          x: this.$element.scrollLeft(),
+          y: this.$element.scrollTop()
+        };
+
+        var _this = this;
+        this.$element.bind(scrollEvent, function() {
+          var scrollHandler;
+
+          if (!(_this.didScroll || isTouch)) {
+           _this.didScroll = true;
+            scrollHandler = function() {
+              _this.doScroll();
+              return _this.didScroll = false;
+            };
+            return window.setTimeout(scrollHandler, $[wps].settings.scrollThrottle);
+          }
+        });
+      }
+
+      Context.prototype.unbindScroll = function(){
+        this.$element.unbind(scrollEvent);
+      }
+      
       Context.prototype.doScroll = function() {
         var axes,
           _this = this;


### PR DESCRIPTION
I have added 2 function to the Context so we can unbind scrollEvent and rebind it anytime. Sometimes we don't want waypoints to fire when we do programmatic scrollTo() maybe even on other case.

Problem is how do we get access to theses function ? Context is an attribute of all waypoints but in my case I have better access to the container element. For now I've add Context to the container element like that : 

``` javascript
$element.data('wp-context', this);
```

I guess you'll find a better way to offer accessibility over Context class or maybe move theses functions somewhere else.
