### PR TITLE
Add ability to .filter() infinite items from $data

### DIFF
--- a/src/shortcuts/infinite.js
+++ b/src/shortcuts/infinite.js
@@ -31,7 +31,12 @@
         var $data = $($.parseHTML(data))
         var $newMore = $data.find(this.options.more)
 
-        this.$container.append($data.find(this.options.items))
+        var $items = $data.find(this.options.items)
+        if (!$items.length) {
+          $items = $data.filter(this.options.items)
+        }
+
+        this.$container.append($items)
         this.$container.removeClass(this.options.loadingClass)
 
         if (!$newMore.length) {


### PR DESCRIPTION
You try to `.filter()` $data for new more link (if it couldn't be found with `.find()`), why not for items?