### PR TITLE
Allow for pre-existing wrapper

### DIFF
--- a/src/shortcuts/sticky.js
+++ b/src/shortcuts/sticky.js
@@ -35,7 +35,7 @@
 
   /* Private */
   Sticky.prototype.createWrapper = function() {
-    if (this.options.wrapper !== false) {
+    if (this.options.wrapper) {
       this.$element.wrap(this.options.wrapper)
     }
     this.$wrapper = this.$element.parent()

--- a/src/shortcuts/sticky.js
+++ b/src/shortcuts/sticky.js
@@ -35,7 +35,9 @@
 
   /* Private */
   Sticky.prototype.createWrapper = function() {
-    this.$element.wrap(this.options.wrapper)
+    if (this.options.wrapper !== false) {
+      this.$element.wrap(this.options.wrapper)
+    }
     this.$wrapper = this.$element.parent()
     this.wrapper = this.$wrapper[0]
   }


### PR DESCRIPTION
At times it may be desirable to have a pre-existing wrapper for sticky items (e.g. to prevent flashes of content if the wrapper needs an offset).

I don't have time to add a test at the moment, but if it will help a merge, I can work on it when I get time!