### PR TITLE
Account for breaking change in jQuery 3 offset()

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -182,7 +182,7 @@
     /*eslint-disable eqeqeq */
     var isWindow = this.element == this.element.window
     /*eslint-enable eqeqeq */
-    var contextOffset = this.adapter.offset()
+    var contextOffset = isWindow ? undefined : this.adapter.offset()
     var triggeredGroups = {}
     var axes
 


### PR DESCRIPTION
As of jQuery 3.0.0-alpha1, the `offset()` method does not silently catch any errors when attempting to call into `getClientRects` on an element that does not have that method (`window`). This is a change to the jQuery use-case / error-handling philosophy. See also: jquery/jquery#2310

Here is a fiddle demonstrating the issue (view runtime error in console): http://jsfiddle.net/es0h3azp/

This PR prevents any calls to `offset()` on `window` that would produce the error.

Unfortunately, I couldn't reproduce the issue in unit tests after pointing to jQuery 3.0.0-alpha1. Presumably this is due to issues with the window object mock?