### PR TITLE
This checks for a negative position on pageYOffset.

### DIFF
--- a/src/adapters/noframework.js
+++ b/src/adapters/noframework.js
@@ -129,7 +129,7 @@
 
   NoFrameworkAdapter.prototype.scrollTop = function() {
     var win = getWindow(this.element)
-    return win ? win.pageYOffset : this.element.scrollTop
+    return win ? (win.pageYOffset > 0) ? win.pageYOffset: 0 : this.element.scrollTop
   }
 
   NoFrameworkAdapter.extend = function() {


### PR DESCRIPTION
Problem: On Safari iOS, if pageYOffset has a negative value, waypoint will automatically fire. 
Solution: Add check to see if pageYOffset is greater than 0.

Gif of problem:

![waypoints](https://cloud.githubusercontent.com/assets/8405274/14603659/0f46b250-053d-11e6-878d-c15fdb6a6e9c.gif)

Page example of problem (please view in Safari on an iOS device):

http://ryanhagerty.com/waypoints.html