### PR TITLE
Only trigger fresh waypoints that are within the viewable area

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -226,6 +226,7 @@
         var freshWaypoint = oldTriggerPoint == null
         var contextModifier, wasBeforeScroll, nowAfterScroll
         var triggeredBackward, triggeredForward
+        var afterTop, beforeBottom
 
         if (waypoint.element !== waypoint.element.window) {
           elementOffset = waypoint.adapter.offset()[axis.offsetProp]
@@ -256,9 +257,14 @@
           waypoint.queueTrigger(axis.forward)
           triggeredGroups[waypoint.group.id] = waypoint.group
         }
-        else if (freshWaypoint && axis.oldScroll >= waypoint.triggerPoint) {
-          waypoint.queueTrigger(axis.forward)
-          triggeredGroups[waypoint.group.id] = waypoint.group
+        else if (freshWaypoint) {
+          afterTop = axis.oldScroll <= waypoint.triggerPoint
+          beforeBottom = axis.oldScroll + axis.contextDimension >= waypoint.triggerPoint
+          if (afterTop && beforeBottom) {
+            waypoint.queueTrigger(axis.forward)
+            waypoint.queueTrigger(axis.backward)
+            triggeredGroups[waypoint.group.id] = waypoint.group
+          }
         }
       }
     }


### PR DESCRIPTION
It doesn’t make sense to trigger fresh waypoints that are already
outside of the visible area of the scrollable context. The waypoints
may be initialised when the context has already been scrolled somewhat.

This change will only trigger a fresh waypoint if that waypoint is
between the top and bottom of the visible area of the scrollable
context. It triggers both forward and back because there is no concept
of just ‘visible’.
