### PR TITLE
document.documentElement.clientWidth -> window.innerWidth 

### DIFF
--- a/src/waypoint.js
+++ b/src/waypoint.js
@@ -137,7 +137,7 @@
   /* Public */
   /* http://imakewebthings.com/waypoints/api/viewport-width */
   Waypoint.viewportWidth = function() {
-    return document.documentElement.clientWidth
+    return window.innerWidth
   }
 
   Waypoint.adapters = []


### PR DESCRIPTION
to prevent reflow when intializing waypoints
