### PR TITLE
Check if fresh waypoint should be triggered in backward direction

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -260,6 +260,10 @@
           waypoint.queueTrigger(axis.forward)
           triggeredGroups[waypoint.group.id] = waypoint.group
         }
+        else if (freshWaypoint && axis.oldScroll < waypoint.triggerPoint) {
+          waypoint.queueTrigger(axis.backward)
+          triggeredGroups[waypoint.group.id] = waypoint.group
+        }
       }
     }
 


### PR DESCRIPTION
Fix for fresh waypoints not triggering in backwards direction.

Possible fix for #508 
