### PR TITLE
Check that oldWindowLoad is a function in src/context.js

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -291,7 +291,7 @@
   }
 
   window.onload = function() {
-    if (oldWindowLoad) {
+    if (typeof oldWindowLoad === 'function') {
       oldWindowLoad()
     }
     Context.refreshAll()


### PR DESCRIPTION
Prevent warning in Firefox console:

> TypeError: oldWindowLoad is not a function

(Note: I noticed this error when using waypoint as provided by the Wordpress plugin Elementor, see https://github.com/pojome/elementor/tree/master/assets/lib/waypoints for their implementation of the code).