### PR TITLE
Add semicolon to end of primary module

### DIFF
--- a/src/waypoint.js
+++ b/src/waypoint.js
@@ -161,4 +161,4 @@
   }
 
   window.Waypoint = Waypoint
-}())
+}());


### PR DESCRIPTION
Some package bundlers can't import Waypoints properly because the lack of a semicolon after the IIFE, which throws off their parsers.