### PR TITLE
If this context IS the window, don't create a new window context

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -30,9 +30,14 @@
     element.waypointContextKey = this.key
     contexts[element.waypointContextKey] = this
     keyCounter += 1
+
     if (!Waypoint.windowContext) {
       Waypoint.windowContext = true
-      Waypoint.windowContext = new Context(window)
+      if (element == window) {
+        Waypoint.windowContext = this;
+      } else {
+        Waypoint.windowContext = new Context(window)
+      }
     }
 
     this.createThrottledScrollHandler()


### PR DESCRIPTION
In the current build, an unnecessary context is created if the first context created is given the window as an element, which is the default. This PR fixes that.