### PR TITLE
Update jquery.waypoints.js to support jQuery 3.3+

### DIFF
--- a/lib/jquery.waypoints.js
+++ b/lib/jquery.waypoints.js
@@ -633,7 +633,7 @@ https://github.com/imakewebthings/waypoints/blob/master/licenses.txt
       var waypoints = []
       var overrides = arguments[0]
 
-      if (framework.isFunction(arguments[0])) {
+      if (typeof arguments[0] === "function"){
         overrides = framework.extend({}, arguments[1])
         overrides.handler = arguments[0]
       }


### PR DESCRIPTION
Changing to use typeof arguments[0] === "function instead of $.isFunction(arguments[0]) to support the latest versions of jQuery, since $.isFunction() is deprecated as of jQuery 3.3

https://api.jquery.com/jquery.isfunction/